### PR TITLE
Add mobile navigation toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,6 +10,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -57,5 +58,6 @@
       </div>
     </div>
   </footer>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
       <nav>
         <ul>
           <li><a href="index.html" class="active">Home</a></li>
@@ -104,5 +105,6 @@
       </div>
     </div>
   </footer>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/menu.html
+++ b/menu.html
@@ -10,6 +10,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">&#9776;</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -87,5 +88,6 @@
       </div>
     </div>
   </footer>
+  <script src="nav.js"></script>
 </body>
 </html>

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,7 @@
+const navToggle = document.querySelector('.nav-toggle');
+const nav = document.querySelector('nav');
+if (navToggle && nav) {
+  navToggle.addEventListener('click', () => {
+    nav.classList.toggle('open');
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -49,6 +49,15 @@ nav ul li a.active, nav ul li a:hover {
   border-bottom: 2px solid #FFD600;
 }
 
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: #FFD600;
+  font-size: 1.8rem;
+  cursor: pointer;
+}
+
 .hero {
   min-height: 350px;
   background: url('B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg') center/cover no-repeat;
@@ -227,5 +236,30 @@ footer {
   .reviews-order {
     flex-direction: column;
     gap: 2.1rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .header-container {
+    position: relative;
+  }
+  nav {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: #222;
+    width: 100%;
+  }
+  nav.open {
+    display: block;
+  }
+  nav ul {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem;
+  }
+  .nav-toggle {
+    display: block;
   }
 }


### PR DESCRIPTION
## Summary
- add hamburger menu button and toggle script
- hide navigation links on small screens and reveal when toggled

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689597ca7d848321be70699d6e66cab1