### PR TITLE
Add responsive 480px breakpoint for small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -229,3 +229,60 @@ footer {
     gap: 2.1rem;
   }
 }
+
+@media (max-width: 480px) {
+  body {
+    font-size: 0.95rem;
+  }
+  header {
+    padding: 0.4rem 0;
+  }
+  .logo a {
+    font-size: 1.4rem;
+  }
+  nav ul {
+    flex-direction: column;
+    gap: 0.7rem;
+    align-items: center;
+  }
+  .hero {
+    min-height: 280px;
+  }
+  .hero-overlay {
+    padding: 1.5rem 1rem;
+  }
+  .hero h1 {
+    font-size: 2rem;
+  }
+  .hero p {
+    font-size: 1rem;
+  }
+  .btn-primary,
+  .btn-secondary {
+    padding: 0.6rem 1.3rem;
+    font-size: 0.95rem;
+  }
+  .about {
+    gap: 1.5rem;
+  }
+  .menu-grid {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  .menu-item {
+    width: 100%;
+    max-width: 300px;
+  }
+  .reviews-order {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  .gallery .gallery-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+  .video-gallery .video-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add `@media (max-width: 480px)` breakpoint to shrink fonts, spacing, and vertically stack grids

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx playwright install chromium` *(fails: 403 Forbidden)*
- `npx puppeteer --help` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689597cdab9c8321b4be008205f21114