### PR TITLE
Add accessible labels and autofill hints to forms

### DIFF
--- a/catering.html
+++ b/catering.html
@@ -38,13 +38,13 @@
       </ul>
       <form class="order-form" style="max-width: 560px; margin:2rem auto;">
         <label for="cateringName">Name</label>
-        <input type="text" id="cateringName" required>
+        <input type="text" id="cateringName" name="name" autocomplete="name" required>
         <label for="cateringEmail">Email</label>
-        <input type="email" id="cateringEmail" required>
+        <input type="email" id="cateringEmail" name="email" autocomplete="email" required>
         <label for="cateringPhone">Phone</label>
-        <input type="tel" id="cateringPhone" required>
+        <input type="tel" id="cateringPhone" name="phone" autocomplete="tel" required>
         <label for="cateringDetails">Event Details (date, time, number of guests, menu requests, etc.)</label>
-        <textarea id="cateringDetails" rows="5" required></textarea>
+        <textarea id="cateringDetails" name="details" rows="5" required></textarea>
         <button type="submit" class="btn-primary">Request Catering Info</button>
       </form>
       <div style="text-align:center;margin-top:2rem;">

--- a/contact.html
+++ b/contact.html
@@ -52,11 +52,11 @@
         <h2>Send a Message</h2>
         <form>
           <label for="contactName">Name</label>
-          <input type="text" id="contactName" required>
+          <input type="text" id="contactName" name="name" autocomplete="name" required>
           <label for="contactEmail">Email</label>
-          <input type="email" id="contactEmail" required>
+          <input type="email" id="contactEmail" name="email" autocomplete="email" required>
           <label for="contactMessage">Message</label>
-          <textarea id="contactMessage" rows="4" required></textarea>
+          <textarea id="contactMessage" name="message" rows="4" required></textarea>
           <button type="submit" class="btn-primary">Send</button>
         </form>
       </div>

--- a/index.html
+++ b/index.html
@@ -83,11 +83,16 @@
       <div class="order-form">
         <h2>Order Online</h2>
         <form>
-          <input type="text" placeholder="Name" required>
-          <input type="tel" placeholder="Phone" required>
-          <input type="date" placeholder="Date" required>
-          <input type="time" placeholder="Time" required>
-          <textarea placeholder="Order Details" required></textarea>
+          <label for="homeName" class="sr-only">Name</label>
+          <input type="text" id="homeName" name="name" placeholder="Name" autocomplete="name" required>
+          <label for="homePhone" class="sr-only">Phone</label>
+          <input type="tel" id="homePhone" name="phone" placeholder="Phone" autocomplete="tel" required>
+          <label for="homeDate" class="sr-only">Date</label>
+          <input type="date" id="homeDate" name="date" placeholder="Date" required>
+          <label for="homeTime" class="sr-only">Time</label>
+          <input type="time" id="homeTime" name="time" placeholder="Time" required>
+          <label for="homeDetails" class="sr-only">Order Details</label>
+          <textarea id="homeDetails" name="details" placeholder="Order Details" required></textarea>
           <button type="submit" class="btn-primary">Send</button>
         </form>
       </div>

--- a/order.html
+++ b/order.html
@@ -32,17 +32,17 @@
       <p>Fill out the form below and we'll get your order ready for pickup or delivery. For large or catering orders, please use the <a href="catering.html">Catering page</a>.</p>
       <form class="order-form" style="max-width: 540px; margin:2rem auto;">
         <label for="orderName">Name</label>
-        <input type="text" id="orderName" required>
+        <input type="text" id="orderName" name="name" autocomplete="name" required>
         <label for="orderPhone">Phone</label>
-        <input type="tel" id="orderPhone" required>
+        <input type="tel" id="orderPhone" name="phone" autocomplete="tel" required>
         <label for="orderEmail">Email</label>
-        <input type="email" id="orderEmail" required>
+        <input type="email" id="orderEmail" name="email" autocomplete="email" required>
         <label for="orderItems">Order Details (items, quantities, sides, etc.)</label>
-        <textarea id="orderItems" rows="4" required></textarea>
+        <textarea id="orderItems" name="details" rows="4" required></textarea>
         <label for="orderDate">Pickup/Delivery Date</label>
-        <input type="date" id="orderDate" required>
+        <input type="date" id="orderDate" name="date" required>
         <label for="orderTime">Pickup/Delivery Time</label>
-        <input type="time" id="orderTime" required>
+        <input type="time" id="orderTime" name="time" required>
         <button type="submit" class="btn-primary">Submit Order</button>
       </form>
       <div style="text-align:center;margin-top:2rem;">

--- a/reviews.html
+++ b/reviews.html
@@ -51,9 +51,9 @@
         <h2>Share Your Experience!</h2>
         <form>
           <label for="reviewerName">Name</label>
-          <input type="text" id="reviewerName" placeholder="Your Name" required>
+          <input type="text" id="reviewerName" name="name" placeholder="Your Name" autocomplete="name" required>
           <label for="reviewText">Your Review</label>
-          <textarea id="reviewText" placeholder="Tell us what you loved!" required></textarea>
+          <textarea id="reviewText" name="review" placeholder="Tell us what you loved!" required></textarea>
           <button type="submit" class="btn-primary">Submit Review</button>
         </form>
         <p><em>Thank you for supporting Southern Love Kitchen!</em></p>

--- a/styles.css
+++ b/styles.css
@@ -186,6 +186,12 @@ nav ul li a.active, nav ul li a:hover {
   border-radius: 11px;
   box-shadow: 0 3px 13px rgba(0,0,0,0.07);
 }
+.order-form form label {
+  display: block;
+  width: 95%;
+  margin: 0.5rem 0 0 0;
+  font-weight: 600;
+}
 .order-form form input, .order-form form textarea {
   width: 95%;
   font-size: 1.06rem;
@@ -196,6 +202,18 @@ nav ul li a.active, nav ul li a:hover {
   background: #f6f6f6;
   resize: none;
   outline: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 footer {
   background: #222;


### PR DESCRIPTION
## Summary
- add hidden labels and identifiers to the homepage order form for better autofill
- include name and autocomplete attributes across order, contact, catering, and review forms
- style form labels and add reusable sr-only utility class

## Testing
- `xmllint --noout index.html order.html contact.html catering.html reviews.html`
- `npx htmlhint index.html order.html contact.html catering.html reviews.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689597d1affc832187c1f48674117046