### PR TITLE
fix: correct video MIME types for .mov files

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -47,49 +47,49 @@
         <div class="video-item">
           <h3>Big Mama’s Mac & Cheese Pull</h3>
           <video controls width="100%">
-            <source src="f3fe625a4de24d078c0bcdaf0137040e.mov" type="video/mp4">
+            <source src="f3fe625a4de24d078c0bcdaf0137040e.mov" type="video/quicktime">
           </video>
           <p class="caption">Just listen to that cheese stretch. Comfort food at its finest—made with love, baked with soul.</p>
         </div>
         <div class="video-item">
           <h3>Country Gold Turkey Wings</h3>
           <video controls width="100%">
-            <source src="f8ae8a9f72d74bb3b737b5eadbde8841.mov" type="video/mp4">
+            <source src="f8ae8a9f72d74bb3b737b5eadbde8841.mov" type="video/quicktime">
           </video>
           <p class="caption">Juicy, golden, and dripping with flavor—smothered turkey wings like Grandma made ‘em.</p>
         </div>
         <div class="video-item">
           <h3>Southern Sizzle Platter</h3>
           <video controls width="100%">
-            <source src="914701ce28934c9686f0feed7a951d1c.mov" type="video/mp4">
+            <source src="914701ce28934c9686f0feed7a951d1c.mov" type="video/quicktime">
           </video>
           <p class="caption">Hot out the pan and ready to serve—hear that sizzle, taste the South.</p>
         </div>
         <div class="video-item">
           <h3>Backyard Bayou Shrimp Fry</h3>
           <video controls width="100%">
-            <source src="7d0a986deb1442b0b1e7554bbac58233.mov" type="video/mp4">
+            <source src="7d0a986deb1442b0b1e7554bbac58233.mov" type="video/quicktime">
           </video>
           <p class="caption">Jumbo shrimp fried up crisp—straight out the bayou and into your heart.</p>
         </div>
         <div class="video-item">
           <h3>Sweet Heat in the Kitchen</h3>
           <video controls width="100%">
-            <source src="f83e6d4fe4504054b2b396b7b4ed959d.mov" type="video/mp4">
+            <source src="f83e6d4fe4504054b2b396b7b4ed959d.mov" type="video/quicktime">
           </video>
           <p class="caption">When the sauce hits just right—sweet, spicy, and oh so soulful.</p>
         </div>
         <div class="video-item">
           <h3>Butter & Soul Mash-Up</h3>
           <video controls width="100%">
-            <source src="8166fdd8b15d4af48f3455cf6ce7dd86.mov" type="video/mp4">
+            <source src="8166fdd8b15d4af48f3455cf6ce7dd86.mov" type="video/quicktime">
           </video>
           <p class="caption">Whipping up buttery mashed potatoes with a side of Southern charm.</p>
         </div>
         <div class="video-item">
           <h3>Sunday Spread: The Classics</h3>
           <video controls width="100%">
-            <source src="d1d5d027fb2a44a594f421715e277844.mov" type="video/mp4">
+            <source src="d1d5d027fb2a44a594f421715e277844.mov" type="video/quicktime">
           </video>
           <p class="caption">A plate piled high with all your favorites. This is what Sundays are made for.</p>
         </div>


### PR DESCRIPTION
## Summary
- Use `video/quicktime` MIME type for `.mov` sources in gallery

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689597e37ac083219151fd53444cf53d