### PR TITLE
Add basic authentication backend and forms

### DIFF
--- a/login.html
+++ b/login.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login - Southern Love Kitchen</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <div class="container header-container">
+      <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <nav>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h2>Login</h2>
+    <form id="loginForm">
+      <label>Username:
+        <input type="text" name="username" required>
+      </label>
+      <label>Password:
+        <input type="password" name="password" required>
+      </label>
+      <button type="submit" class="btn-primary">Login</button>
+    </form>
+    <p>Don't have an account? <a href="register.html">Register</a></p>
+  </main>
+
+  <script src="scripts/auth.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "southern-love-kitchen",
+  "version": "1.0.0",
+  "description": "Modern restaurant &amp; catering website for Southern Love Kitchen. Built with HTML and CSS.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.1"
+  }
+}

--- a/register.html
+++ b/register.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Register - Southern Love Kitchen</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <div class="container header-container">
+      <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <nav>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h2>Register</h2>
+    <form id="registerForm">
+      <label>Username:
+        <input type="text" name="username" required>
+      </label>
+      <label>Password:
+        <input type="password" name="password" required>
+      </label>
+      <button type="submit" class="btn-primary">Register</button>
+    </form>
+    <p>Already have an account? <a href="login.html">Login</a></p>
+  </main>
+
+  <script src="scripts/auth.js"></script>
+</body>
+</html>

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loginForm = document.getElementById('loginForm');
+  const registerForm = document.getElementById('registerForm');
+  const logoutBtn = document.getElementById('logoutBtn');
+
+  async function handleAuth(url, form) {
+    const formData = new FormData(form);
+    const body = {
+      username: formData.get('username'),
+      password: formData.get('password')
+    };
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      const data = await res.json();
+      if (res.ok && data.token) {
+        localStorage.setItem('token', data.token);
+        alert('Success');
+      } else {
+        alert(data.error || 'Request failed');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Network error');
+    }
+  }
+
+  if (loginForm) {
+    loginForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      handleAuth('/auth/login', loginForm);
+    });
+  }
+
+  if (registerForm) {
+    registerForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      handleAuth('/auth/register', registerForm);
+    });
+  }
+
+  if (logoutBtn) {
+    logoutBtn.addEventListener('click', () => {
+      localStorage.removeItem('token');
+      alert('Logged out');
+    });
+  }
+});

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const authRoutes = require('./routes/auth');
+
+const app = express();
+app.use(express.json());
+
+app.use('/auth', authRoutes);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+
+const router = express.Router();
+
+// In-memory user store
+const users = {}; // { username: passwordHash }
+
+const JWT_SECRET = process.env.JWT_SECRET || 'supersecretkey';
+
+// POST /auth/register
+router.post('/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password required' });
+  }
+  if (users[username]) {
+    return res.status(409).json({ error: 'User already exists' });
+  }
+  try {
+    const hashedPassword = await bcrypt.hash(password, 10);
+    users[username] = hashedPassword;
+    const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1h' });
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// POST /auth/login
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  const hashedPassword = users[username];
+  if (!hashedPassword) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const match = await bcrypt.compare(password, hashedPassword);
+  if (!match) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1h' });
+  res.json({ token });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- set up Express server with /auth routes for user registration and login using bcrypt and JWT
- add login and registration pages plus client-side auth script storing tokens and handling logout
- add Node project configuration

## Testing
- `npm test`
- `node server/index.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_689599cf98fc8321aa9c333cb86ba4a4