### PR TITLE
Add notification backend and profile widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+notifications.db

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "southern-love-kitchen",
+  "version": "1.0.0",
+  "description": "Southern Love Kitchen website",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6",
+    "nodemailer": "^6.9.4",
+    "node-cron": "^3.0.2"
+  }
+}

--- a/profile.html
+++ b/profile.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>User Profile - Southern Love Kitchen</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <div class="container header-container">
+      <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <nav>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="menu.html">Menu</a></li>
+          <li><a href="order.html">Order Online</a></li>
+          <li><a href="catering.html">Catering</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="gallery.html">Gallery</a></li>
+          <li><a href="reviews.html">Reviews</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <h1>User Profile</h1>
+    <section id="notifications-widget">
+      <h2>Current Promotions</h2>
+      <ul id="notifications-list"></ul>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-container">
+      <p>&copy; 2025 Southern Love Kitchen. All rights reserved.</p>
+      <div class="footer-social">
+        <a href="#">Instagram</a> |
+        <a href="#">Facebook</a> |
+        <a href="#">TikTok</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    fetch('/notifications')
+      .then((response) => response.json())
+      .then((data) => {
+        const list = document.getElementById('notifications-list');
+        if (data.length === 0) {
+          list.innerHTML = '<li>No promotions at this time.</li>';
+          return;
+        }
+        data.forEach((n) => {
+          const li = document.createElement('li');
+          li.textContent = `${n.title}: ${n.message}`;
+          list.appendChild(li);
+        });
+      })
+      .catch((err) => console.error('Error fetching notifications', err));
+  </script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,82 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const nodemailer = require('nodemailer');
+const cron = require('node-cron');
+const path = require('path');
+
+const app = express();
+const db = new sqlite3.Database('./notifications.db');
+
+// Initialize table
+db.serialize(() => {
+  db.run(`CREATE TABLE IF NOT EXISTS notifications (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    message TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    sent INTEGER DEFAULT 0
+  )`);
+});
+
+const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'secret123';
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname)));
+
+app.get('/notifications', (req, res) => {
+  db.all(
+    `SELECT id, title, message, created_at FROM notifications ORDER BY created_at DESC`,
+    [],
+    (err, rows) => {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json(rows);
+    }
+  );
+});
+
+app.post('/notifications', (req, res) => {
+  if (req.headers['x-admin-token'] !== ADMIN_TOKEN) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  const { title, message } = req.body;
+  if (!title || !message) {
+    return res.status(400).json({ error: 'Title and message required' });
+  }
+  const stmt = db.prepare(
+    `INSERT INTO notifications (title, message, sent) VALUES (?, ?, 0)`
+  );
+  stmt.run(title, message, function (err) {
+    if (err) return res.status(500).json({ error: err.message });
+    res.status(201).json({ id: this.lastID, title, message });
+  });
+});
+
+// Email transport using JSON output (for demonstration)
+const transporter = nodemailer.createTransport({ jsonTransport: true });
+
+// Cron job to send unsent notifications every 10 seconds
+cron.schedule('*/10 * * * * *', () => {
+  db.all(`SELECT id, title, message FROM notifications WHERE sent = 0`, [], (err, rows) => {
+    if (err) return console.error(err);
+    rows.forEach((row) => {
+      const mailOptions = {
+        from: 'no-reply@southern-love-kitchen.test',
+        to: 'user@example.com',
+        subject: row.title,
+        text: row.message,
+      };
+      transporter.sendMail(mailOptions, (error, info) => {
+        if (error) {
+          return console.error(error);
+        }
+        db.run(`UPDATE notifications SET sent = 1 WHERE id = ?`, [row.id]);
+        console.log('Notification sent:', info.messageId);
+      });
+    });
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Express server with SQLite-backed notifications, admin POST /notifications, user GET endpoint and scheduled email dispatch
- add profile page with dashboard widget that fetches and displays current promotions
- set up nodemailer cron job for sending notifications

## Testing
- `npm test`
- `node server.js` *(fails: Cannot find module 'express' due to install restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689599dd99b48321a8b32800abd3eb5f