### PR TITLE
Validate notification channel in user route

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "echo \"No tests\""
+    "test": "node --test tests/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const router = express.Router();
 
+const allowedChannels = ['email', 'sms', 'phone'];
+
 let currentUser = {
   name: 'Anonymous',
   contact: '',
-  notificationChannel: 'email'
+  notificationChannel: 'email',
 };
 
 router.get('/me', (req, res) => {
@@ -16,6 +18,9 @@ router.patch('/me', (req, res) => {
   if (typeof name !== 'undefined') currentUser.name = name;
   if (typeof contact !== 'undefined') currentUser.contact = contact;
   if (typeof notificationChannel !== 'undefined') {
+    if (!allowedChannels.includes(notificationChannel)) {
+      return res.status(400).json({ error: 'Invalid channel' });
+    }
     currentUser.notificationChannel = notificationChannel;
   }
   res.json(currentUser);

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -1,0 +1,46 @@
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const express = require('express');
+
+let server;
+let base;
+
+beforeEach(() => {
+  delete require.cache[require.resolve('../server/routes/users')];
+  const usersRouter = require('../server/routes/users');
+  const app = express();
+  app.use(express.json());
+  app.use('/users', usersRouter);
+  server = app.listen(0);
+  base = `http://localhost:${server.address().port}`;
+});
+
+afterEach(() => {
+  server.close();
+});
+
+test('accepts valid notification channel', async () => {
+  const res = await fetch(`${base}/users/me`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ notificationChannel: 'sms' }),
+  });
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.strictEqual(body.notificationChannel, 'sms');
+});
+
+test('rejects invalid notification channel', async () => {
+  const res = await fetch(`${base}/users/me`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ notificationChannel: 'pigeon' }),
+  });
+  assert.strictEqual(res.status, 400);
+  const body = await res.json();
+  assert.deepStrictEqual(body, { error: 'Invalid channel' });
+
+  const getRes = await fetch(`${base}/users/me`);
+  const getBody = await getRes.json();
+  assert.strictEqual(getBody.notificationChannel, 'email');
+});


### PR DESCRIPTION
## Summary
- limit `notificationChannel` to email, sms, or phone
- send 400 error for invalid channels
- add Node tests for valid and invalid update scenarios

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pip install beautifulsoup4` *(fails: Could not find a version that satisfies the requirement due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68959e261afc83218255586c93d73c16