### PR TITLE
Relax navigation link test

### DIFF
--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -27,7 +27,7 @@ def test_navigation_links_and_active(html_file):
     assert nav is not None, f"{html_file} is missing a <nav> element"
 
     links = {a.get("href") for a in nav.find_all("a", href=True)}
-    assert links == REQUIRED_LINKS, f"Unexpected links in {html_file}: {links}" 
+    assert REQUIRED_LINKS.issubset(links), f"Missing required links in {html_file}: {links}"
 
     active_links = [a for a in nav.find_all("a", href=True) if "active" in a.get("class", [])]
     assert len(active_links) == 1, f"{html_file} should have exactly one active link"


### PR DESCRIPTION
## Summary
- loosen navigation link check to require only presence of required links

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68959e1458948321b7eef47d7ab7fbc1