### PR TITLE
Add profile page loading, validation, and styling enhancements

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -30,23 +30,32 @@
   </header>
 
   <main>
+    <section class="hero profile-hero">
+      <div class="hero-overlay">
+        <h1>Your Profile</h1>
+      </div>
+    </section>
     <section class="profile container">
-      <h1>Your Profile</h1>
-      <form id="profileForm" class="profile-form">
-        <label for="name">Name</label>
-        <input type="text" id="name" />
+      <div class="profile-card">
+        <div class="avatar-placeholder"></div>
+        <div id="spinner" class="spinner"></div>
+        <form id="profileForm" class="profile-form" style="display:none;">
+          <label for="name">Name</label>
+          <input type="text" id="name" />
 
-        <label for="contact">Contact Info</label>
-        <input type="text" id="contact" />
+          <label for="contact">Contact Info</label>
+          <input type="text" id="contact" />
 
-        <label for="notificationChannel">Preferred Notification Channel</label>
-        <select id="notificationChannel">
-          <option value="email">Email</option>
-          <option value="sms">SMS</option>
-          <option value="phone">Phone</option>
-        </select>
-        <button type="submit" class="btn-primary">Save</button>
-      </form>
+          <label for="notificationChannel">Preferred Notification Channel</label>
+          <select id="notificationChannel">
+            <option value="email">Email</option>
+            <option value="sms">SMS</option>
+            <option value="phone">Phone</option>
+          </select>
+          <button type="submit" class="btn-primary">Save</button>
+        </form>
+        <div id="formMessage" class="form-message"></div>
+      </div>
     </section>
   </main>
 

--- a/scripts/profile.js
+++ b/scripts/profile.js
@@ -1,10 +1,21 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+
   const nameInput = document.getElementById('name');
   const contactInput = document.getElementById('contact');
   const channelSelect = document.getElementById('notificationChannel');
   const form = document.getElementById('profileForm');
+  const spinner = document.getElementById('spinner');
+  const message = document.getElementById('formMessage');
+  const saveBtn = form.querySelector('button');
 
-  fetch('/users/me')
+  fetch('/users/me', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
     .then((res) => {
       if (!res.ok) throw new Error('Failed to fetch profile');
       return res.json();
@@ -13,21 +24,36 @@ document.addEventListener('DOMContentLoaded', () => {
       nameInput.value = data.name || '';
       contactInput.value = data.contact || '';
       channelSelect.value = data.notificationChannel || 'email';
+      form.style.display = 'block';
     })
-    .catch((err) => alert('Update failed'));
+    .catch(() => {
+      message.textContent = 'Failed to load profile';
+      message.className = 'form-message error';
+    })
+    .finally(() => {
+      spinner.style.display = 'none';
+    });
 
   form.addEventListener('submit', (e) => {
     e.preventDefault();
+    message.textContent = '';
+    if (!nameInput.value.trim() || !contactInput.value.trim()) {
+      message.textContent = 'Please fill out all fields.';
+      message.className = 'form-message error';
+      return;
+    }
     const payload = {
       name: nameInput.value,
       contact: contactInput.value,
       notificationChannel: channelSelect.value,
     };
 
+    saveBtn.disabled = true;
     fetch('/users/me', {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(payload),
     })
@@ -35,9 +61,16 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!res.ok) throw new Error('Failed to update profile');
         return res.json();
       })
-      .then((data) => {
-        alert('Profile updated');
+      .then(() => {
+        message.textContent = 'Profile updated successfully';
+        message.className = 'form-message success';
       })
-      .catch((err) => alert('Update failed'));
+      .catch(() => {
+        message.textContent = 'Update failed';
+        message.className = 'form-message error';
+      })
+      .finally(() => {
+        saveBtn.disabled = false;
+      });
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -220,6 +220,63 @@ nav ul li a.active::after, nav ul li a:hover::after {
   resize: none;
   outline: none;
 }
+
+/* Profile page styles */
+.profile-hero {
+  min-height: 40vh;
+}
+.profile-card {
+  background: #fff;
+  padding: 2rem 1.5rem;
+  border-radius: 15px;
+  box-shadow: 0 3px 13px rgba(0,0,0,0.07);
+  max-width: 400px;
+  margin: -3rem auto 2rem;
+  text-align: center;
+}
+.avatar-placeholder {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: #e0e0e0;
+  margin: 0 auto 1rem;
+}
+.profile-form label {
+  display: block;
+  text-align: left;
+  margin: 0.5rem 0 0.25rem;
+}
+.profile-form input,
+.profile-form select {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  margin-bottom: 0.9rem;
+  border-radius: 8px;
+  border: 1px solid var(--accent);
+  background: #f6f6f6;
+}
+.form-message {
+  margin-top: 1rem;
+}
+.form-message.success {
+  color: green;
+}
+.form-message.error {
+  color: red;
+}
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid var(--accent);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+  margin: 1rem auto;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 footer {
   background: #222;
   color: #fff;


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users and show a spinner while loading profile data
- Validate inputs, display inline success and error messages, and disable save button during updates
- Introduce hero header, avatar placeholder, and card-styled profile form with spinner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a18b1ddc8321871b0c072450302e