### PR TITLE
Add branded login page with authentication enhancements

### DIFF
--- a/login.html
+++ b/login.html
@@ -33,13 +33,20 @@
   </header>
 
   <main>
-    <section class="container login">
-      <h1>Login</h1>
-      <form class="login-form">
-        <input type="email" placeholder="Email" required>
-        <input type="password" placeholder="Password" required>
-        <button type="submit" class="btn-primary">Login</button>
-      </form>
+    <section class="login-banner">
+      <div class="login container">
+        <h1>Login</h1>
+        <form id="loginForm" class="login-form">
+          <input type="email" id="email" placeholder="Email" required>
+          <div class="password-field">
+            <input type="password" id="password" placeholder="Password" required>
+            <button type="button" class="toggle-password">Show</button>
+          </div>
+          <label class="remember-me"><input type="checkbox" id="rememberMe"> Remember me</label>
+          <div class="error-message" id="loginError"></div>
+          <button type="submit" class="btn-primary">Login</button>
+        </form>
+      </div>
     </section>
   </main>
 
@@ -54,5 +61,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
+  <script src="scripts/login.js"></script>
 </body>
 </html>

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -3,8 +3,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const logoutLink = document.getElementById('logoutLink');
   const profileLink = document.getElementById('profileLink');
 
+  function getToken() {
+    return localStorage.getItem('token') || sessionStorage.getItem('token');
+  }
+
+  function clearToken() {
+    localStorage.removeItem('token');
+    sessionStorage.removeItem('token');
+  }
+
   function updateNav() {
-    const token = localStorage.getItem('token');
+    const token = getToken();
     if (token) {
       if (loginLink) loginLink.style.display = 'none';
       if (logoutLink) logoutLink.style.display = 'list-item';
@@ -19,7 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (logoutLink) {
     logoutLink.addEventListener('click', (e) => {
       e.preventDefault();
-      localStorage.removeItem('token');
+      clearToken();
       updateNav();
     });
   }

--- a/scripts/login.js
+++ b/scripts/login.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('loginForm');
+  const emailInput = document.getElementById('email');
+  const passwordInput = document.getElementById('password');
+  const togglePassword = document.querySelector('.toggle-password');
+  const rememberMe = document.getElementById('rememberMe');
+  const errorMsg = document.getElementById('loginError');
+
+  togglePassword.addEventListener('click', () => {
+    const type = passwordInput.type === 'password' ? 'text' : 'password';
+    passwordInput.type = type;
+    togglePassword.textContent = type === 'password' ? 'Show' : 'Hide';
+  });
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    errorMsg.textContent = '';
+    const email = emailInput.value.trim();
+    const password = passwordInput.value.trim();
+
+    if (email === 'user@example.com' && password === 'password123') {
+      const token = 'demo-token';
+      if (rememberMe.checked) {
+        localStorage.setItem('token', token);
+      } else {
+        sessionStorage.setItem('token', token);
+      }
+      window.location.href = 'profile.html';
+    } else {
+      errorMsg.textContent = 'Invalid email or password.';
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -309,3 +309,60 @@ footer {
     gap: 1rem;
   }
 }
+
+/* Login Page Styles */
+.login-banner {
+  min-height: 60vh;
+  background: url('B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg') center/cover no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.login {
+  background: rgba(255,255,255,0.95);
+  padding: 2rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+  max-width: 400px;
+  width: 100%;
+}
+
+.login-form input[type="email"],
+.login-form input[type="password"] {
+  width: 100%;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+
+.password-field {
+  position: relative;
+}
+
+.password-field .toggle-password {
+  position: absolute;
+  top: 50%;
+  right: 1rem;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--dark);
+}
+
+.remember-me {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.login-form .error-message {
+  color: red;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- Add restaurant-branded banner and enhanced login form with show/hide password, Remember me option and inline errors
- Style new login components and background for visual consistency
- Implement login.js for credential validation and update auth.js to handle session/local tokens

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4'; unable to install dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6895a17d86a88321a51c81204bcb8adf