### PR TITLE
Add lazy-loading media with lightbox and hover effects

### DIFF
--- a/about.html
+++ b/about.html
@@ -48,7 +48,7 @@
         </p>
       </div>
       <div class="about-img">
-        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Chef Meechii">
+        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Chef Meechii" loading="lazy">
       </div>
     </section>
   </main>

--- a/gallery.html
+++ b/gallery.html
@@ -41,9 +41,24 @@
       </p>
       <div class="gallery-grid">
         <!-- Your uploaded food images -->
-        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Mac & Cheese Tray">
-        <img src="B10887C6-E88A-487F-8D56-EE57326ADEAD.jpeg" alt="Turkey Wings Plate">
-        <img src="1DF9B4A1-AFB2-4F71-A9D2-7FC4D48DEC6C.jpeg" alt="Loaded Southern Plate">
+        <figure class="gallery-item">
+          <a href="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" class="lightbox">
+            <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Mac &amp; cheese tray" loading="lazy">
+          </a>
+          <figcaption>Mac &amp; Cheese Tray</figcaption>
+        </figure>
+        <figure class="gallery-item">
+          <a href="B10887C6-E88A-487F-8D56-EE57326ADEAD.jpeg" class="lightbox">
+            <img src="B10887C6-E88A-487F-8D56-EE57326ADEAD.jpeg" alt="Turkey wings plate" loading="lazy">
+          </a>
+          <figcaption>Turkey Wings Plate</figcaption>
+        </figure>
+        <figure class="gallery-item">
+          <a href="1DF9B4A1-AFB2-4F71-A9D2-7FC4D48DEC6C.jpeg" class="lightbox">
+            <img src="1DF9B4A1-AFB2-4F71-A9D2-7FC4D48DEC6C.jpeg" alt="Loaded southern plate" loading="lazy">
+          </a>
+          <figcaption>Loaded Southern Plate</figcaption>
+        </figure>
       </div>
     </section>
 
@@ -51,53 +66,67 @@
       <h2>Soulful Moments: Watch Us in Action</h2>
       <div class="video-grid">
         <div class="video-item">
-          <h3>Big Mama’s Mac & Cheese Pull</h3>
-          <video controls width="100%">
-            <source src="f3fe625a4de24d078c0bcdaf0137040e.mov" type="video/quicktime">
-          </video>
-          <p class="caption">Just listen to that cheese stretch. Comfort food at its finest—made with love, baked with soul.</p>
+          <h3>Big Mama’s Mac &amp; Cheese Pull</h3>
+          <div class="video-wrapper">
+            <video controls width="100%" loading="lazy" aria-label="Mac and cheese pull">
+              <source src="f3fe625a4de24d078c0bcdaf0137040e.mov" type="video/quicktime">
+            </video>
+            <p class="caption">Just listen to that cheese stretch. Comfort food at its finest—made with love, baked with soul.</p>
+          </div>
         </div>
         <div class="video-item">
           <h3>Country Gold Turkey Wings</h3>
-          <video controls width="100%">
-            <source src="f8ae8a9f72d74bb3b737b5eadbde8841.mov" type="video/quicktime">
-          </video>
-          <p class="caption">Juicy, golden, and dripping with flavor—smothered turkey wings like Grandma made ‘em.</p>
+          <div class="video-wrapper">
+            <video controls width="100%" loading="lazy" aria-label="Turkey wings">
+              <source src="f8ae8a9f72d74bb3b737b5eadbde8841.mov" type="video/quicktime">
+            </video>
+            <p class="caption">Juicy, golden, and dripping with flavor—smothered turkey wings like Grandma made ‘em.</p>
+          </div>
         </div>
         <div class="video-item">
           <h3>Southern Sizzle Platter</h3>
-          <video controls width="100%">
-            <source src="914701ce28934c9686f0feed7a951d1c.mov" type="video/quicktime">
-          </video>
-          <p class="caption">Hot out the pan and ready to serve—hear that sizzle, taste the South.</p>
+          <div class="video-wrapper">
+            <video controls width="100%" loading="lazy" aria-label="Southern sizzle platter">
+              <source src="914701ce28934c9686f0feed7a951d1c.mov" type="video/quicktime">
+            </video>
+            <p class="caption">Hot out the pan and ready to serve—hear that sizzle, taste the South.</p>
+          </div>
         </div>
         <div class="video-item">
           <h3>Backyard Bayou Shrimp Fry</h3>
-          <video controls width="100%">
-            <source src="7d0a986deb1442b0b1e7554bbac58233.mov" type="video/quicktime">
-          </video>
-          <p class="caption">Jumbo shrimp fried up crisp—straight out the bayou and into your heart.</p>
+          <div class="video-wrapper">
+            <video controls width="100%" loading="lazy" aria-label="Shrimp fry">
+              <source src="7d0a986deb1442b0b1e7554bbac58233.mov" type="video/quicktime">
+            </video>
+            <p class="caption">Jumbo shrimp fried up crisp—straight out the bayou and into your heart.</p>
+          </div>
         </div>
         <div class="video-item">
           <h3>Sweet Heat in the Kitchen</h3>
-          <video controls width="100%">
-            <source src="f83e6d4fe4504054b2b396b7b4ed959d.mov" type="video/quicktime">
-          </video>
-          <p class="caption">When the sauce hits just right—sweet, spicy, and oh so soulful.</p>
+          <div class="video-wrapper">
+            <video controls width="100%" loading="lazy" aria-label="Sweet heat in the kitchen">
+              <source src="f83e6d4fe4504054b2b396b7b4ed959d.mov" type="video/quicktime">
+            </video>
+            <p class="caption">When the sauce hits just right—sweet, spicy, and oh so soulful.</p>
+          </div>
         </div>
         <div class="video-item">
-          <h3>Butter & Soul Mash-Up</h3>
-          <video controls width="100%">
-            <source src="8166fdd8b15d4af48f3455cf6ce7dd86.mov" type="video/quicktime">
-          </video>
-          <p class="caption">Whipping up buttery mashed potatoes with a side of Southern charm.</p>
+          <h3>Butter &amp; Soul Mash-Up</h3>
+          <div class="video-wrapper">
+            <video controls width="100%" loading="lazy" aria-label="Butter and soul mash-up">
+              <source src="8166fdd8b15d4af48f3455cf6ce7dd86.mov" type="video/quicktime">
+            </video>
+            <p class="caption">Whipping up buttery mashed potatoes with a side of Southern charm.</p>
+          </div>
         </div>
         <div class="video-item">
           <h3>Sunday Spread: The Classics</h3>
-          <video controls width="100%">
-            <source src="d1d5d027fb2a44a594f421715e277844.mov" type="video/quicktime">
-          </video>
-          <p class="caption">A plate piled high with all your favorites. This is what Sundays are made for.</p>
+          <div class="video-wrapper">
+            <video controls width="100%" loading="lazy" aria-label="Sunday spread classics">
+              <source src="d1d5d027fb2a44a594f421715e277844.mov" type="video/quicktime">
+            </video>
+            <p class="caption">A plate piled high with all your favorites. This is what Sundays are made for.</p>
+          </div>
         </div>
       </div>
       <div class="gallery-social">
@@ -118,44 +147,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
-  <style>
-    .gallery-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 1.2rem;
-      margin-top: 2rem;
-      margin-bottom: 2rem;
-    }
-    .gallery-grid img {
-      width: 100%;
-      border-radius: 14px;
-      box-shadow: 0 4px 18px rgba(0,0,0,0.07);
-      object-fit: cover;
-      transition: transform 0.2s;
-    }
-    .gallery-grid img:hover {
-      transform: scale(1.04);
-    }
-    .video-gallery {
-      margin-top: 2.5rem;
-    }
-    .video-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-      gap: 2.2rem;
-    }
-    .video-item h3 { margin: 0.7rem 0 0.3rem 0;}
-    .caption {
-      font-size: 1.08rem;
-      color: #444;
-      margin-top: 0.5rem;
-      font-style: italic;
-    }
-    .gallery-social {
-      text-align: center;
-      margin-top: 2.5rem;
-      margin-bottom: 2rem;
-    }
-  </style>
+  <script src="scripts/lightbox.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         </p>
       </div>
       <div class="about-img">
-        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Signature Southern Dish">
+        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Mac &amp; cheese tray" loading="lazy">
       </div>
     </section>
 
@@ -57,14 +57,14 @@
       <h2>Menu</h2>
       <div class="menu-grid">
         <div class="menu-item">
-          <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Customer Favorite">
+          <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Mac &amp; cheese tray" loading="lazy">
           <span class="badge">Customer Favorite</span>
         </div>
         <div class="menu-item">
-          <img src="B10887C6-E88A-487F-8D56-EE57326ADEAD.jpeg" alt="Dish 2">
+          <img src="B10887C6-E88A-487F-8D56-EE57326ADEAD.jpeg" alt="Turkey wings plate" loading="lazy">
         </div>
         <div class="menu-item">
-          <img src="1DF9B4A1-AFB2-4F71-A9D2-7FC4D48DEC6C.jpeg" alt="Dish 3">
+          <img src="1DF9B4A1-AFB2-4F71-A9D2-7FC4D48DEC6C.jpeg" alt="Loaded southern plate" loading="lazy">
         </div>
       </div>
       <a href="menu.html" class="btn-secondary">See Full Menu</a>

--- a/scripts/lightbox.js
+++ b/scripts/lightbox.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const links = document.querySelectorAll('a.lightbox');
+  if (!links.length) return;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'lightbox-overlay';
+  const img = document.createElement('img');
+  overlay.appendChild(img);
+
+  overlay.addEventListener('click', () => {
+    overlay.classList.remove('active');
+    img.removeAttribute('src');
+  });
+
+  document.body.appendChild(overlay);
+
+  links.forEach(link => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      img.src = link.getAttribute('href');
+      overlay.classList.add('active');
+    });
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -220,6 +220,131 @@ nav ul li a.active::after, nav ul li a:hover::after {
   resize: none;
   outline: none;
 }
+
+/* Gallery styles */
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.2rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+.gallery-item {
+  position: relative;
+  overflow: hidden;
+  border-radius: 14px;
+  box-shadow: 0 4px 18px rgba(0,0,0,0.07);
+  margin: 0;
+}
+.gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.3s;
+}
+.gallery-item:hover img {
+  transform: scale(1.05);
+}
+.gallery-item figcaption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  opacity: 0;
+  transform: translateY(100%);
+  transition: opacity 0.3s, transform 0.3s;
+  text-align: center;
+}
+.gallery-item:hover figcaption {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Video gallery styles */
+.video-gallery {
+  margin-top: 2.5rem;
+  background: #f1e5d1;
+  padding: 2rem 0;
+}
+.video-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2.2rem;
+}
+.video-item {
+  transition: transform 0.3s;
+}
+.video-item:hover {
+  transform: translateY(-4px);
+}
+.video-wrapper {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 4px 18px rgba(0,0,0,0.07);
+}
+.video-wrapper video {
+  width: 100%;
+  display: block;
+  transition: transform 0.3s;
+}
+.video-wrapper:hover video {
+  transform: scale(1.05);
+}
+.video-wrapper .caption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  opacity: 0;
+  transform: translateY(100%);
+  transition: opacity 0.3s, transform 0.3s;
+}
+.video-wrapper:hover .caption {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.video-item h3 {
+  margin: 0.7rem 0 0.3rem 0;
+}
+
+.gallery-social {
+  text-align: center;
+  margin-top: 2.5rem;
+  margin-bottom: 2rem;
+}
+
+/* Lightbox overlay */
+.lightbox-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.85);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+.lightbox-overlay img {
+  max-width: 90%;
+  max-height: 90%;
+  border-radius: 10px;
+}
+.lightbox-overlay.active {
+  display: flex;
+}
 footer {
   background: #222;
   color: #fff;


### PR DESCRIPTION
## Summary
- lazily load gallery images and videos with concise alt text for accessibility
- add lightbox viewer, hover captions, and section styling for richer media interaction
- introduce darker video gallery background with smooth transitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a17ab6d0832199940a100e6440fb