### PR TITLE
Add catering hero imagery and form confirmation modal

### DIFF
--- a/catering.html
+++ b/catering.html
@@ -33,16 +33,19 @@
   </header>
 
   <main>
-    <section class="container">
+    <section class="container catering-section">
       <h1>Catering & Events</h1>
-      <p>We cater events of all sizes—family gatherings, corporate lunches, weddings, church picnics, and more! Our Southern comfort classics will have your guests coming back for seconds.</p>
-      <ul>
-        <li>Custom menus available for your event</li>
-        <li>Pickup, drop-off, and full-service options</li>
-        <li>Dietary accommodations on request</li>
-        <li>Party platters, boxed meals, and more!</li>
-      </ul>
-      <form class="order-form" style="max-width: 560px; margin:2rem auto;">
+      <img src="https://via.placeholder.com/1200x400?text=Catering+Events" alt="Collage of past Southern Love Kitchen catering events with buffet tables and guests enjoying meals" class="catering-hero-img">
+      <div class="catering-content-block">
+        <p>We cater events of all sizes—family gatherings, corporate lunches, weddings, church picnics, and more! Our Southern comfort classics will have your guests coming back for seconds.</p>
+        <ul>
+          <li>Custom menus available for your event</li>
+          <li>Pickup, drop-off, and full-service options</li>
+          <li>Dietary accommodations on request</li>
+          <li>Party platters, boxed meals, and more!</li>
+        </ul>
+      </div>
+      <form class="order-form catering-content-block" style="max-width: 560px; margin:2rem auto;">
         <label for="cateringName">Name</label>
         <input type="text" id="cateringName" name="name" required>
         <label for="cateringEmail">Email</label>
@@ -59,6 +62,12 @@
       </div>
     </section>
   </main>
+  <div id="cateringModal" class="modal" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <p>Thanks for reaching out! Our team will contact you soon.</p>
+      <button id="modalClose" class="btn-primary">Close</button>
+    </div>
+  </div>
 
   <footer>
     <div class="container footer-container">
@@ -70,6 +79,7 @@
       </div>
     </div>
   </footer>
+  <script src="scripts/catering.js"></script>
   <script src="scripts/auth.js"></script>
 </body>
 </html>

--- a/scripts/catering.js
+++ b/scripts/catering.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('.order-form');
+  const modal = document.getElementById('cateringModal');
+  const closeBtn = document.getElementById('modalClose');
+
+  if (form) {
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      if (modal) {
+        modal.style.display = 'flex';
+      }
+      form.reset();
+    });
+  }
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      if (modal) {
+        modal.style.display = 'none';
+      }
+    });
+  }
+
+  if (modal) {
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) {
+        modal.style.display = 'none';
+      }
+    });
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -309,3 +309,70 @@ footer {
     gap: 1rem;
   }
 }
+
+/* Catering page enhancements */
+.catering-section {
+  background: repeating-linear-gradient(45deg, #fff9de, #fff9de 20px, #fff 20px, #fff 40px);
+  padding: 2rem 0;
+}
+
+.catering-section h1 {
+  font-size: 2.5rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.catering-hero-img {
+  width: 100%;
+  border-radius: 12px;
+  margin: 1rem 0 2rem;
+}
+
+.catering-content-block {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 12px;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}
+
+.catering-content-block ul {
+  font-size: 1.1rem;
+}
+
+.catering-content-block p {
+  font-size: 1.15rem;
+}
+
+.catering-section label {
+  font-size: 1rem;
+}
+
+.catering-section button {
+  font-size: 1.1rem;
+}
+
+.modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.6);
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  text-align: center;
+  max-width: 400px;
+}
+
+.modal-content button {
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- add event collage hero image and structured content blocks on catering page
- implement confirmation modal for catering info requests
- style catering section with patterned background and font hierarchy

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4'; attempted installation but proxy returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895a17466cc8321a56a3e0f4c416c64