### PR TITLE
Refactor contact page styling and add form validation

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -38,15 +38,15 @@
       <p>Have a question? Want to order by phone or chat about your event? Reach out!</p>
       <div class="contact-info-grid">
         <div>
-          <h3>Phone</h3>
+          <h3>📞 Phone</h3>
           <p><a href="tel:5555555555">(555) 555-5555</a></p>
         </div>
         <div>
-          <h3>Email</h3>
+          <h3>✉️ Email</h3>
           <p><a href="mailto:info@southernlovekitchen.com">info@southernlovekitchen.com</a></p>
         </div>
         <div>
-          <h3>Address</h3>
+          <h3>📍 Address</h3>
           <p>123 Southern Ave, Alexandria, VA 22306</p>
         </div>
         <div>
@@ -66,10 +66,10 @@
           <button type="submit" class="btn-primary">Send</button>
         </form>
       </div>
-      <div class="map-embed" style="margin-top:2rem;">
-        <h3>Find Us</h3>
+      <div class="map-embed">
+        <h3>📍 Find Us</h3>
         <!-- Replace the src below with your actual location if available -->
-        <iframe src="https://maps.google.com/maps?q=Alexandria,VA,22306&z=15&output=embed" width="100%" height="220" frameborder="0" style="border:0; border-radius:10px;" allowfullscreen></iframe>
+        <iframe src="https://maps.google.com/maps?q=Alexandria,VA,22306&z=15&output=embed" frameborder="0" allowfullscreen></iframe>
       </div>
     </section>
   </main>
@@ -85,24 +85,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
-  <style>
-    .contact-info-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 1.2rem;
-      margin: 2rem 0 2rem 0;
-      text-align: center;
-    }
-    .contact-info-grid h3 { margin-bottom: 0.3rem; }
-    .contact-form {
-      background: #f8f7f4;
-      padding: 1.7rem 1.2rem;
-      border-radius: 12px;
-      box-shadow: 0 2px 10px rgba(0,0,0,0.03);
-      max-width: 600px;
-      margin: 2rem auto 0 auto;
-    }
-    .map-embed iframe { width: 100%; border-radius: 12px; }
-  </style>
+  <script src="scripts/contact.js"></script>
 </body>
 </html>

--- a/scripts/contact.js
+++ b/scripts/contact.js
@@ -1,0 +1,27 @@
+// Simple contact form validation
+// Adds error class to empty or invalid fields and shows success alert on submit
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('.contact-form form');
+  if (!form) return;
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    let valid = true;
+
+    form.querySelectorAll('input, textarea').forEach((field) => {
+      field.classList.remove('error');
+      const isEmail = field.type === 'email';
+      const value = field.value.trim();
+      if (!value || (isEmail && !/^\S+@\S+\.\S+$/.test(value))) {
+        field.classList.add('error');
+        valid = false;
+      }
+    });
+
+    if (valid) {
+      alert('Thank you! Your message has been sent.');
+      form.reset();
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -238,6 +238,40 @@ footer {
   text-decoration: underline;
 }
 
+/* Contact page */
+.contact-info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.2rem;
+  margin: 2rem 0;
+  text-align: center;
+}
+.contact-info-grid h3 {
+  margin-bottom: 0.3rem;
+}
+.contact-form {
+  background: #f8f7f4;
+  padding: 1.7rem 1.2rem;
+  border-radius: 12px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.03);
+  max-width: 600px;
+  margin: 2rem auto 0;
+}
+.contact-form input.error,
+.contact-form textarea.error {
+  border-color: #e74c3c;
+}
+.map-embed {
+  margin-top: 2rem;
+}
+.map-embed iframe {
+  width: 100%;
+  aspect-ratio: 16/9;
+  border-radius: 12px;
+  border: 1px solid #ddd;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
 @media (max-width: 820px) {
   .about {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- move contact page inline styles to shared stylesheet and add icons
- add responsive map styling and error highlighting
- implement client-side contact form validation with success alert

## Testing
- `npm test`
- `pytest` *(fails: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_6895a1723dd0832181392cfa1c781633