### PR TITLE
Refactor contact page styling and add client-side validation

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -56,14 +56,18 @@
       </div>
       <div class="contact-form">
         <h2>Send a Message</h2>
-        <form>
+        <form id="contactForm" novalidate>
           <label for="contactName">Name</label>
           <input type="text" id="contactName" name="name" required>
+          <span class="error" id="nameError"></span>
           <label for="contactEmail">Email</label>
           <input type="email" id="contactEmail" name="email" required>
+          <span class="error" id="emailError"></span>
           <label for="contactMessage">Message</label>
           <textarea id="contactMessage" name="message" rows="4" required></textarea>
+          <span class="error" id="messageError"></span>
           <button type="submit" class="btn-primary">Send</button>
+          <div id="contactStatus" class="form-message"></div>
         </form>
       </div>
       <div class="map-embed">
@@ -85,5 +89,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
+  <script src="scripts/contact.js"></script>
 </body>
 </html>

--- a/scripts/contact.js
+++ b/scripts/contact.js
@@ -1,0 +1,55 @@
+// Client-side validation for the contact form
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('contactForm');
+  const nameInput = document.getElementById('contactName');
+  const emailInput = document.getElementById('contactEmail');
+  const messageInput = document.getElementById('contactMessage');
+  const status = document.getElementById('contactStatus');
+  const nameError = document.getElementById('nameError');
+  const emailError = document.getElementById('emailError');
+  const messageError = document.getElementById('messageError');
+
+  function clearErrors() {
+    nameError.textContent = '';
+    emailError.textContent = '';
+    messageError.textContent = '';
+    status.textContent = '';
+    status.className = 'form-message';
+  }
+
+  function showError(el, message) {
+    el.textContent = message;
+  }
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    clearErrors();
+    let valid = true;
+
+    if (nameInput.value.trim() === '') {
+      showError(nameError, 'Name is required.');
+      valid = false;
+    }
+
+    const emailPattern = /^[\w.-]+@[\w.-]+\.[A-Za-z]{2,}$/;
+    if (!emailPattern.test(emailInput.value.trim())) {
+      showError(emailError, 'Please enter a valid email.');
+      valid = false;
+    }
+
+    if (messageInput.value.trim().length < 10) {
+      showError(messageError, 'Message must be at least 10 characters.');
+      valid = false;
+    }
+
+    if (valid) {
+      status.textContent = 'Message sent!';
+      status.classList.add('success');
+      form.reset();
+    } else {
+      status.textContent = 'Please correct the errors above.';
+      status.classList.add('error');
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -392,6 +392,35 @@ footer {
   margin: 2rem auto 0 auto;
 }
 
+.contact-form form {
+  display: flex;
+  flex-direction: column;
+}
+
+.contact-form label {
+  margin-top: 0.5rem;
+  margin-bottom: 0.25rem;
+  font-weight: 600;
+}
+
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: 0.6rem 0.8rem;
+  margin-bottom: 0.6rem;
+  border-radius: 8px;
+  border: 1px solid var(--accent);
+  background: #f6f6f6;
+  box-sizing: border-box;
+}
+
+.contact-form .error {
+  color: red;
+  font-size: 0.9rem;
+  margin-top: -0.5rem;
+  margin-bottom: 0.5rem;
+}
+
 .reviews-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));


### PR DESCRIPTION
## Summary
- style contact form with consistent layout and error messaging
- add client-side validation for contact form fields
- load new contact.js on contact page

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*


------
https://chatgpt.com/codex/tasks/task_e_68960b77ace48321b11d50fe76723d02