### PR TITLE
Add lazy loading and lightbox for media

### DIFF
--- a/about.html
+++ b/about.html
@@ -48,7 +48,7 @@
         </p>
       </div>
       <div class="about-img">
-        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Chef Meechii">
+        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Chef Meechii" loading="lazy">
       </div>
     </section>
   </main>
@@ -64,5 +64,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
+  <script src="scripts/media.js"></script>
 </body>
 </html>

--- a/gallery.html
+++ b/gallery.html
@@ -41,9 +41,9 @@
       </p>
       <div class="gallery-grid">
         <!-- Your uploaded food images -->
-        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Mac & Cheese Tray">
-        <img src="B10887C6-E88A-487F-8D56-EE57326ADEAD.jpeg" alt="Turkey Wings Plate">
-        <img src="1DF9B4A1-AFB2-4F71-A9D2-7FC4D48DEC6C.jpeg" alt="Loaded Southern Plate">
+        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Mac & Cheese Tray" loading="lazy">
+        <img src="B10887C6-E88A-487F-8D56-EE57326ADEAD.jpeg" alt="Turkey Wings Plate" loading="lazy">
+        <img src="1DF9B4A1-AFB2-4F71-A9D2-7FC4D48DEC6C.jpeg" alt="Loaded Southern Plate" loading="lazy">
       </div>
     </section>
 
@@ -52,49 +52,49 @@
       <div class="video-grid">
         <div class="video-item">
           <h3>Big Mama’s Mac & Cheese Pull</h3>
-          <video controls width="100%">
+          <video controls width="100%" preload="none" loading="lazy">
             <source src="f3fe625a4de24d078c0bcdaf0137040e.mov" type="video/quicktime">
           </video>
           <p class="caption">Just listen to that cheese stretch. Comfort food at its finest—made with love, baked with soul.</p>
         </div>
         <div class="video-item">
           <h3>Country Gold Turkey Wings</h3>
-          <video controls width="100%">
+          <video controls width="100%" preload="none" loading="lazy">
             <source src="f8ae8a9f72d74bb3b737b5eadbde8841.mov" type="video/quicktime">
           </video>
           <p class="caption">Juicy, golden, and dripping with flavor—smothered turkey wings like Grandma made ‘em.</p>
         </div>
         <div class="video-item">
           <h3>Southern Sizzle Platter</h3>
-          <video controls width="100%">
+          <video controls width="100%" preload="none" loading="lazy">
             <source src="914701ce28934c9686f0feed7a951d1c.mov" type="video/quicktime">
           </video>
           <p class="caption">Hot out the pan and ready to serve—hear that sizzle, taste the South.</p>
         </div>
         <div class="video-item">
           <h3>Backyard Bayou Shrimp Fry</h3>
-          <video controls width="100%">
+          <video controls width="100%" preload="none" loading="lazy">
             <source src="7d0a986deb1442b0b1e7554bbac58233.mov" type="video/quicktime">
           </video>
           <p class="caption">Jumbo shrimp fried up crisp—straight out the bayou and into your heart.</p>
         </div>
         <div class="video-item">
           <h3>Sweet Heat in the Kitchen</h3>
-          <video controls width="100%">
+          <video controls width="100%" preload="none" loading="lazy">
             <source src="f83e6d4fe4504054b2b396b7b4ed959d.mov" type="video/quicktime">
           </video>
           <p class="caption">When the sauce hits just right—sweet, spicy, and oh so soulful.</p>
         </div>
         <div class="video-item">
           <h3>Butter & Soul Mash-Up</h3>
-          <video controls width="100%">
+          <video controls width="100%" preload="none" loading="lazy">
             <source src="8166fdd8b15d4af48f3455cf6ce7dd86.mov" type="video/quicktime">
           </video>
           <p class="caption">Whipping up buttery mashed potatoes with a side of Southern charm.</p>
         </div>
         <div class="video-item">
           <h3>Sunday Spread: The Classics</h3>
-          <video controls width="100%">
+          <video controls width="100%" preload="none" loading="lazy">
             <source src="d1d5d027fb2a44a594f421715e277844.mov" type="video/quicktime">
           </video>
           <p class="caption">A plate piled high with all your favorites. This is what Sundays are made for.</p>
@@ -118,5 +118,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
+  <script src="scripts/media.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         </p>
       </div>
       <div class="about-img">
-        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Signature Southern Dish">
+        <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Signature Southern Dish" loading="lazy">
       </div>
     </section>
 
@@ -57,14 +57,14 @@
       <h2>Menu</h2>
       <div class="menu-grid">
         <div class="menu-item">
-          <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Customer Favorite">
+          <img src="B70EE393-E18C-4EDE-9938-BFCB280F814E.jpeg" alt="Customer Favorite" loading="lazy">
           <span class="badge">Customer Favorite</span>
         </div>
         <div class="menu-item">
-          <img src="B10887C6-E88A-487F-8D56-EE57326ADEAD.jpeg" alt="Dish 2">
+          <img src="B10887C6-E88A-487F-8D56-EE57326ADEAD.jpeg" alt="Dish 2" loading="lazy">
         </div>
         <div class="menu-item">
-          <img src="1DF9B4A1-AFB2-4F71-A9D2-7FC4D48DEC6C.jpeg" alt="Dish 3">
+          <img src="1DF9B4A1-AFB2-4F71-A9D2-7FC4D48DEC6C.jpeg" alt="Dish 3" loading="lazy">
         </div>
       </div>
       <a href="menu.html" class="btn-secondary">See Full Menu</a>
@@ -111,5 +111,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
+  <script src="scripts/media.js"></script>
 </body>
 </html>

--- a/scripts/media.js
+++ b/scripts/media.js
@@ -1,0 +1,72 @@
+// Handles lazy loading and lightbox functionality for images and videos
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Lazy load videos using IntersectionObserver
+  const lazyVideos = document.querySelectorAll('video[preload="none"]');
+  if ('IntersectionObserver' in window) {
+    const videoObserver = new IntersectionObserver((entries, observer) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.load();
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { rootMargin: '200px' });
+    lazyVideos.forEach(video => videoObserver.observe(video));
+  }
+
+  // Create lightbox elements
+  const lightbox = document.createElement('div');
+  lightbox.id = 'lightbox';
+  lightbox.innerHTML = '<span class="lightbox-close">&times;</span>';
+  const lightboxImg = document.createElement('img');
+  const lightboxVideo = document.createElement('video');
+  lightboxVideo.controls = true;
+  lightbox.appendChild(lightboxImg);
+  lightbox.appendChild(lightboxVideo);
+  document.body.appendChild(lightbox);
+
+  function openLightbox(src, type, alt = '') {
+    if (type === 'image') {
+      lightboxImg.src = src;
+      lightboxImg.alt = alt;
+      lightboxImg.style.display = 'block';
+      lightboxVideo.pause();
+      lightboxVideo.src = '';
+      lightboxVideo.style.display = 'none';
+    } else {
+      lightboxVideo.src = src;
+      lightboxVideo.style.display = 'block';
+      lightboxImg.style.display = 'none';
+      lightboxVideo.play();
+    }
+    lightbox.classList.add('show');
+  }
+
+  // Bind click events for images
+  document.querySelectorAll('img').forEach(img => {
+    img.addEventListener('click', () => openLightbox(img.src, 'image', img.alt));
+  });
+
+  // Bind click events for videos
+  document.querySelectorAll('video').forEach(video => {
+    video.addEventListener('click', () => {
+      const source = video.querySelector('source');
+      const src = source ? source.src : video.src;
+      openLightbox(src, 'video');
+    });
+  });
+
+  function closeLightbox() {
+    lightbox.classList.remove('show');
+    lightboxImg.src = '';
+    lightboxVideo.pause();
+    lightboxVideo.src = '';
+  }
+
+  lightbox.addEventListener('click', e => {
+    if (e.target === lightbox || e.target.classList.contains('lightbox-close')) {
+      closeLightbox();
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -525,6 +525,41 @@ footer {
   margin-bottom: 2rem;
 }
 
+#lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+  z-index: 1000;
+}
+
+#lightbox.show {
+  opacity: 1;
+  visibility: visible;
+}
+
+#lightbox img,
+#lightbox video {
+  max-width: 90%;
+  max-height: 90%;
+  border-radius: 8px;
+  display: none;
+}
+
+#lightbox .lightbox-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+}
+
 @media (max-width: 820px) {
   .about {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Add loading="lazy" to images and videos and preload="none" to videos
- Introduce a reusable lightbox with lazy video loading logic
- Style lightbox overlay for media previews

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `pip install beautifulsoup4` *(fails: Could not find a version that satisfies the requirement beautifulsoup4 due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68960dfa0c9c83219b261d0f32bcf01b