### PR TITLE
Break menu into card-based sections

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -37,49 +37,55 @@
       <h1>Our Soulful Menu</h1>
       <p>Made fresh. Made with love. Made for you.</p>
 
-      <!-- Starters -->
-      <h2>Starters & Appetizers</h2>
-      <ul>
-        <li><strong>Cheeseburger Eggroll</strong> — Multi-cheese crunchy beef eggroll, fried perfectly, served with chipotle aioli.</li>
-        <li><strong>Hot Cheeto Chicken Balls</strong> — Chicken and cheese rolled with peppers, coated & dipped in batter, fried to perfection.</li>
-        <li><strong>Quesadillas</strong> — Grilled with three cheeses and peppers. Ooey, gooey, and unforgettable.</li>
-        <li><strong>Meatballs</strong> — Juicy baked meatballs with a Southern twist.</li>
-      </ul>
+      <div class="menu-sections">
+        <div class="menu-card">
+          <h2>Starters &amp; Appetizers</h2>
+          <ul>
+            <li><strong>Cheeseburger Eggroll</strong> — Multi-cheese crunchy beef eggroll, fried perfectly, served with chipotle aioli.</li>
+            <li><strong>Hot Cheeto Chicken Balls</strong> — Chicken and cheese rolled with peppers, coated &amp; dipped in batter, fried to perfection.</li>
+            <li><strong>Quesadillas</strong> — Grilled with three cheeses and peppers. Ooey, gooey, and unforgettable.</li>
+            <li><strong>Meatballs</strong> — Juicy baked meatballs with a Southern twist.</li>
+          </ul>
+        </div>
 
-      <!-- Mains -->
-      <h2>Main Courses</h2>
-      <ul>
-        <li><strong>Fried Chicken</strong> — Buttermilk fried golden chicken, crispy on the outside, juicy on the inside.</li>
-        <li><strong>Fried Fish</strong> — Fresh whiting fish dipped in our Cajun fish fry batter and fried to perfection.</li>
-        <li><strong>Fried Jumbo Shrimp</strong> — Jumbo shrimp perfectly fried, also available in buffalo.</li>
-        <li><strong>Jerk Rasta Pasta</strong> — Creamy, spicy pasta packed with island flavor. Choose chicken, shrimp, or steak.</li>
-        <li><strong>Baked Smothered Turkey Wings</strong> — Slow-cooked turkey wings with delicious country gravy (or jerk sauce on request).</li>
-        <li><strong>Lamb Chop</strong> — Grass-fed lamb, seasoned and seared with red wine.</li>
-      </ul>
+        <div class="menu-card">
+          <h2>Main Courses</h2>
+          <ul>
+            <li><strong>Fried Chicken</strong> — Buttermilk fried golden chicken, crispy on the outside, juicy on the inside.</li>
+            <li><strong>Fried Fish</strong> — Fresh whiting fish dipped in our Cajun fish fry batter and fried to perfection.</li>
+            <li><strong>Fried Jumbo Shrimp</strong> — Jumbo shrimp perfectly fried, also available in buffalo.</li>
+            <li><strong>Jerk Rasta Pasta</strong> — Creamy, spicy pasta packed with island flavor. Choose chicken, shrimp, or steak.</li>
+            <li><strong>Baked Smothered Turkey Wings</strong> — Slow-cooked turkey wings with delicious country gravy (or jerk sauce on request).</li>
+            <li><strong>Lamb Chop</strong> — Grass-fed lamb, seasoned and seared with red wine.</li>
+          </ul>
+        </div>
 
-      <!-- Sides -->
-      <h2>Sides</h2>
-      <ul>
-        <li><strong>Baked Beans</strong> — Savory beans, slow-cooked with ground beef & spices for a bold kick!</li>
-        <li><strong>Mac & Cheese</strong> — Heavenly cheesy macaroni with a golden crust.</li>
-        <li><strong>Green Beans</strong> — Fresh-snapped, slow-cooked in smoked turkey.</li>
-        <li><strong>Mash Potatoes</strong> — Creamy garlic mashed potatoes made with Irish butter.</li>
-        <li><strong>Broccoli</strong> — Fresh, sautéed with salt, pepper, garlic, and butter.</li>
-        <li><strong>Loaded Baked Potatoes</strong> — Jumbo baked potato with salt, pepper, sour cream, cheese, bacon bites & green onion (add steak if you like).</li>
-        <li><strong>Asparagus</strong> — Sautéed in garlic lemon herb butter.</li>
-        <li><strong>Collard Greens</strong> — Southern-style collard & kale greens, slow-cooked with smoked turkey.</li>
-        <li><strong>Yellow Rice</strong> — Cooked down with red peppers for big flavor.</li>
-        <li><strong>Cabbage</strong> — Southern cabbage, slow-cooked with smoked turkey.</li>
-        <li><strong>Rolls</strong> — Fresh-baked and perfect for sopping up every last drop.</li>
-      </ul>
+        <div class="menu-card">
+          <h2>Sides</h2>
+          <ul>
+            <li><strong>Baked Beans</strong> — Savory beans, slow-cooked with ground beef &amp; spices for a bold kick!</li>
+            <li><strong>Mac &amp; Cheese</strong> — Heavenly cheesy macaroni with a golden crust.</li>
+            <li><strong>Green Beans</strong> — Fresh-snapped, slow-cooked in smoked turkey.</li>
+            <li><strong>Mash Potatoes</strong> — Creamy garlic mashed potatoes made with Irish butter.</li>
+            <li><strong>Broccoli</strong> — Fresh, sautéed with salt, pepper, garlic, and butter.</li>
+            <li><strong>Loaded Baked Potatoes</strong> — Jumbo baked potato with salt, pepper, sour cream, cheese, bacon bites &amp; green onion (add steak if you like).</li>
+            <li><strong>Asparagus</strong> — Sautéed in garlic lemon herb butter.</li>
+            <li><strong>Collard Greens</strong> — Southern-style collard &amp; kale greens, slow-cooked with smoked turkey.</li>
+            <li><strong>Yellow Rice</strong> — Cooked down with red peppers for big flavor.</li>
+            <li><strong>Cabbage</strong> — Southern cabbage, slow-cooked with smoked turkey.</li>
+            <li><strong>Rolls</strong> — Fresh-baked and perfect for sopping up every last drop.</li>
+          </ul>
+        </div>
 
-      <!-- Desserts -->
-      <h2>Desserts</h2>
-      <ul>
-        <li><strong>Honey Strawberry Cornbread</strong> — Homemade cornbread with fresh strawberries and sweet glazed top.</li>
-        <li><strong>Strawberry Shortcake</strong> — Homemade vanilla and strawberry cake with light sweet icing and wafer topper.</li>
-        <li><strong>Lemon Blueberry Cupcakes</strong> — Homemade cupcakes with lemon, blueberry, and a vanilla drizzle.</li>
-      </ul>
+        <div class="menu-card">
+          <h2>Desserts</h2>
+          <ul>
+            <li><strong>Honey Strawberry Cornbread</strong> — Homemade cornbread with fresh strawberries and sweet glazed top.</li>
+            <li><strong>Strawberry Shortcake</strong> — Homemade vanilla and strawberry cake with light sweet icing and wafer topper.</li>
+            <li><strong>Lemon Blueberry Cupcakes</strong> — Homemade cupcakes with lemon, blueberry, and a vanilla drizzle.</li>
+          </ul>
+        </div>
+      </div>
     </section>
   </main>
 

--- a/styles.css
+++ b/styles.css
@@ -192,6 +192,29 @@ nav ul li a.active::after, nav ul li a:hover::after {
 .menu.container {
   margin-bottom: 3.5rem;
 }
+
+/* Full menu page */
+.menu-sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.7rem;
+  margin-top: 2rem;
+}
+
+.menu-card {
+  background: #fff;
+  border-radius: 15px;
+  box-shadow: 0 3px 17px rgba(0,0,0,0.06);
+  padding: 1.5rem;
+}
+
+.menu-card h2 {
+  margin-top: 0;
+}
+
+.menu-card ul {
+  padding-left: 1.2rem;
+}
 .menu-grid {
   display: flex;
   gap: 1.7rem;


### PR DESCRIPTION
## Summary
- Restructure menu page into grid of category cards for starters, mains, sides, and desserts
- Style new menu card layout with responsive grid and card visuals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68960dd7e6748321a5a51ab2ac23e5c5