### PR TITLE
Add responsive navigation toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -65,5 +66,6 @@
   </footer>
   <script src="scripts/auth.js"></script>
   <script src="scripts/media.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/catering.html
+++ b/catering.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -77,5 +78,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -90,5 +91,6 @@
   </footer>
   <script src="scripts/auth.js"></script>
   <script src="scripts/contact.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -75,5 +76,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/gallery.html
+++ b/gallery.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -119,5 +120,6 @@
   </footer>
   <script src="scripts/auth.js"></script>
   <script src="scripts/media.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html" class="active">Home</a></li>
@@ -112,5 +113,6 @@
   </footer>
   <script src="scripts/auth.js"></script>
   <script src="scripts/media.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -62,5 +63,6 @@
   </footer>
   <script src="scripts/auth.js"></script>
   <script src="scripts/login.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/menu.html
+++ b/menu.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -100,5 +101,6 @@
     </div>
   </footer>
   <script src="scripts/auth.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/order.html
+++ b/order.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -83,5 +84,6 @@
   </footer>
   <script src="scripts/auth.js"></script>
   <script src="scripts/order.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -10,6 +10,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -71,5 +72,6 @@
   </footer>
   <script src="scripts/auth.js"></script>
   <script src="scripts/profile.js"></script>
+  <script src="scripts/nav.js"></script>
 </body>
 </html>

--- a/reviews.html
+++ b/reviews.html
@@ -13,6 +13,7 @@
   <header>
     <div class="container header-container">
       <div class="logo"><a href="index.html">Southern Love <span>Kitchen</span></a></div>
+      <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
       <nav>
         <ul>
           <li><a href="index.html">Home</a></li>
@@ -116,6 +117,8 @@
     .thank-you { margin-top: 1rem; font-weight: 600; color: var(--accent); }
     .add-review-form { margin-top: 2rem; padding: 1.5rem; background: #f8f7f4; border-radius: 10px; box-shadow: 0 2px 8px rgba(0,0,0,0.04); max-width: 600px; margin-left: auto; margin-right: auto; }
   </style>
+
+  <script src="scripts/nav.js"></script>
 
 </body>
 </html>

--- a/scripts/nav.js
+++ b/scripts/nav.js
@@ -1,0 +1,10 @@
+// Simple navigation toggle for small screens
+window.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.querySelector('.nav-toggle');
+  const nav = document.querySelector('header nav');
+  if (toggle && nav) {
+    toggle.addEventListener('click', () => {
+      nav.classList.toggle('open');
+    });
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,15 @@ nav ul li a.active::after, nav ul li a:hover::after {
   width: 100%;
 }
 
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.8rem;
+  cursor: pointer;
+}
+
 #profileLink,
 #logoutLink {
   display: none;
@@ -602,6 +611,22 @@ footer {
   .reviews-order {
     flex-direction: column;
     gap: 2.1rem;
+  }
+}
+
+@media (max-width: 768px) {
+  nav {
+    display: none;
+  }
+  nav.open {
+    display: block;
+  }
+  nav ul {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .nav-toggle {
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `nav-toggle` button and include `scripts/nav.js` across all pages for collapsible menus
- Style navigation with media query to hide menus under 768px and reveal the toggle
- Implement simple JavaScript to open and close the menu on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689614ae9b7883219c4b2c656fcdbad6