### PR TITLE
Add Jest testing framework and unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node server/index.js",
-    "test": "node --test tests/*.test.js"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -14,5 +14,12 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^24.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
   }
 }

--- a/tests/login.test.js
+++ b/tests/login.test.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('login form', () => {
+  let form, email, password, remember, error;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <form id="loginForm">
+        <input id="email" />
+        <input id="password" type="password" />
+        <span class="toggle-password">Show</span>
+        <input type="checkbox" id="rememberMe" />
+        <div id="loginError"></div>
+      </form>
+    `;
+    localStorage.clear();
+    sessionStorage.clear();
+    jest.resetModules();
+    require('../scripts/login.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    form = document.getElementById('loginForm');
+    email = document.getElementById('email');
+    password = document.getElementById('password');
+    remember = document.getElementById('rememberMe');
+    error = document.getElementById('loginError');
+    delete window.location;
+    window.location = { href: '' };
+  });
+
+  test('shows error for invalid credentials', () => {
+    email.value = 'wrong@example.com';
+    password.value = 'wrong';
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    expect(error.textContent).toBe('Invalid email or password.');
+  });
+
+  test('stores token in localStorage when remember me checked', () => {
+    email.value = 'user@example.com';
+    password.value = 'password123';
+    remember.checked = true;
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    expect(localStorage.getItem('token')).toBe('demo-token');
+    expect(sessionStorage.getItem('token')).toBeNull();
+  });
+});

--- a/tests/reviews.test.js
+++ b/tests/reviews.test.js
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+describe('reviews', () => {
+  let stars, ratingInput, form, reviewsList;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div class="reviews-list"></div>
+      <div id="reviewRating">
+        <svg data-value="1"></svg>
+        <svg data-value="2"></svg>
+        <svg data-value="3"></svg>
+        <svg data-value="4"></svg>
+        <svg data-value="5"></svg>
+      </div>
+      <input id="rating" value="0" />
+      <div class="add-review-form">
+        <form>
+          <input id="reviewerName" />
+          <textarea id="reviewText"></textarea>
+        </form>
+      </div>
+    `;
+    jest.resetModules();
+    require('../scripts/reviews.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    stars = document.querySelectorAll('#reviewRating svg');
+    ratingInput = document.getElementById('rating');
+    form = document.querySelector('.add-review-form form');
+    reviewsList = document.querySelector('.reviews-list');
+  });
+
+  test('sets rating on star click', () => {
+    stars[2].dispatchEvent(new Event('click'));
+    expect(ratingInput.value).toBe('3');
+    expect(stars[0].classList.contains('filled')).toBe(true);
+    expect(stars[2].classList.contains('filled')).toBe(true);
+    expect(stars[3].classList.contains('filled')).toBe(false);
+  });
+
+  test('does not add review when fields missing', () => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    expect(reviewsList.children.length).toBe(0);
+  });
+
+  test('adds review with valid input and resets rating', () => {
+    document.getElementById('reviewerName').value = 'Alice';
+    document.getElementById('reviewText').value = 'Great!';
+    stars[3].dispatchEvent(new Event('click'));
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    expect(reviewsList.children.length).toBe(1);
+    expect(ratingInput.value).toBe('0');
+  });
+});

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -1,5 +1,6 @@
-const { test, beforeEach, afterEach } = require('node:test');
-const assert = require('node:assert');
+/**
+ * @jest-environment node
+ */
 const express = require('express');
 
 let server;
@@ -23,24 +24,24 @@ test('accepts valid notification channel', async () => {
   const res = await fetch(`${base}/users/me`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ notificationChannel: 'sms' }),
+    body: JSON.stringify({ notificationChannel: 'sms' })
   });
-  assert.strictEqual(res.status, 200);
+  expect(res.status).toBe(200);
   const body = await res.json();
-  assert.strictEqual(body.notificationChannel, 'sms');
+  expect(body.notificationChannel).toBe('sms');
 });
 
 test('rejects invalid notification channel', async () => {
   const res = await fetch(`${base}/users/me`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ notificationChannel: 'pigeon' }),
+    body: JSON.stringify({ notificationChannel: 'pigeon' })
   });
-  assert.strictEqual(res.status, 400);
+  expect(res.status).toBe(400);
   const body = await res.json();
-  assert.deepStrictEqual(body, { error: 'Invalid channel' });
+  expect(body).toEqual({ error: 'Invalid channel' });
 
   const getRes = await fetch(`${base}/users/me`);
   const getBody = await getRes.json();
-  assert.strictEqual(getBody.notificationChannel, 'email');
+  expect(getBody.notificationChannel).toBe('email');
 });


### PR DESCRIPTION
## Summary
- configure Jest with jsdom environment and add to devDependencies
- add unit tests for login form validation, review rating logic, and API routes

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689614bebddc8321adbb31bedb65c9f3